### PR TITLE
Added sort option, defaults to alphabet sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ Template for recursion import, added to the beginning of file.
 
 Template for recursion export, added to the end of file.
 
+### sort
+
+- Type: `alpha | alpha-desc`
+- Default: `alpha`
+
+Determines sorting of exported modules.
+
 ### test
 
 - Type: `boolean`

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ interface Options {
   recursion?: boolean;
   recursionTemplate?: string;
   recursionTemplateExport?: string;
+  sort?: 'alpha' | 'alpha-desc';
   test?: boolean;
 }
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -54,6 +54,11 @@ export const params: { [key: string]: Params } = {
     default: 'export { #recursion };',
     type: 'string',
   },
+  sort: {
+    choices: ['alpha', 'alpha-desc'],
+    default: 'alpha',
+    type: 'string',
+  },
   test: {
     default: false,
     type: 'boolean',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import remove from 'module/fs/remove';
 import update from 'module/fs/update';
 import asDirectory from 'module/resolve/asDirectory';
 import asFile from 'module/resolve/asFile';
+import sort from 'module/sort';
 import { dirname, join, resolve } from 'path';
 import { Module, Options } from 'types';
 import hasProperty from 'utils/hasProperty';
@@ -42,17 +43,7 @@ export default function(patterns?: string | string[], options?: Options): void {
     Object.keys(dirs).forEach(dir => {
       if (hasProperty(dirs, dirname(dir))) {
         const module = asDirectory(dir, dirs[dir], opt);
-        if (module) {
-          dirs[dirname(dir)] = dirs[dirname(dir)]
-            .concat(module)
-            .sort((a, b) => {
-              if (a.isRecursion) return -1;
-              if (b.isRecursion) return 1;
-              if (a.name < b.name) return -1;
-              if (a.name > b.name) return 1;
-              return 0;
-            });
-        }
+        if (module) dirs[dirname(dir)] = dirs[dirname(dir)].concat(module);
       }
     });
   }
@@ -62,7 +53,7 @@ export default function(patterns?: string | string[], options?: Options): void {
     modules: Module[];
   }> = [];
   Object.keys(dirs).forEach(dir => {
-    const modules = dirs[dir];
+    const modules = sort(dirs[dir], opt);
     const contents = createContents(modules, opt);
     const file = `${opt.fileName}.${opt.fileExtension}`;
     const index = join(resolve(process.cwd()), dir, file);

--- a/src/module/sort.ts
+++ b/src/module/sort.ts
@@ -1,0 +1,27 @@
+import { Module, Options } from 'types';
+
+/**
+ * Returns sorted modules.
+ * @param {array} modules List of modules.
+ * @param {object} options Options.
+ */
+
+export default function(modules: Module[], { sort }: Options): Module[] {
+  return modules.sort((a, b) => {
+    switch (sort) {
+      case 'alpha-desc':
+        if (a.isRecursion) return -1;
+        if (b.isRecursion) return 1;
+        if (a.name < b.name) return 1;
+        if (a.name > b.name) return -1;
+        break;
+      default:
+        if (a.isRecursion) return -1;
+        if (b.isRecursion) return 1;
+        if (a.name < b.name) return -1;
+        if (a.name > b.name) return 1;
+        break;
+    }
+    return 0;
+  });
+}


### PR DESCRIPTION
Added new `sort` option for sorting of detected modules, possible values:
- `alpha` - in alphabetical order, this is default
- `alpha-desc` - reverse alphabetical order (solution for #7)

Example
```
$ reexporter <node-glob> --sort alpha-desc
```